### PR TITLE
Fixed missing discovery attr on Artist

### DIFF
--- a/lib/echowrap/artist.rb
+++ b/lib/echowrap/artist.rb
@@ -2,7 +2,7 @@ require 'echowrap/base'
 
 module Echowrap
   class Artist < Echowrap::Base
-    attr_reader :name, :twitter, :id, :familiarity, :hotttnesss
+    attr_reader :name, :twitter, :id, :familiarity, :hotttnesss, :discovery
 
     # @return [Array]
     def biographies


### PR DESCRIPTION
Hey guys. While using this gem I noticed that discovery values weren't available as attributes like the others on the Artist class. Maybe this was intentional and I am missing something, but I threw it in.

I think a genre method may be missing too, but I didn't need it and didn't have time to implement it. Just FYI
