### PR TITLE
Add album information attributes to tracks

### DIFF
--- a/lib/echowrap/track.rb
+++ b/lib/echowrap/track.rb
@@ -10,7 +10,7 @@ module Echowrap
                   :release, :release_image, :sample_md5, :samplerate, :song_id,
                   :start_of_fade_out, :status, :synch_version, :synchstring, :tempo,
                   :tempo_confidence, :time_signature, :time_signature_confidence, :title,
-                  :window_seconds
+                  :window_seconds, :album_type, :album_date, :album_name,
 
       # @return [Echowrap::AudioSummary]
       def audio_summary


### PR DESCRIPTION
Hey guys,

I noticed that there were new attributes available on the Echonest API that weren't on the gem. I tried to get the tests to pass but I was unable to dig deeper into why they weren't passing.

Thanks,
